### PR TITLE
hide axis when creating viewer 2D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v24.0.0
 
 New functionality:
-- Add method to edit axes label text & tests, hide one label on 2D viewer #389
+- Add method to edit axes label text & tests, hide one label on 2D viewer #389 #408
 - Add slider widget #365 and option to not install it #386
 
 Bugfixes:

--- a/Wrappers/Python/ccpi/viewer/QCILViewerWidget.py
+++ b/Wrappers/Python/ccpi/viewer/QCILViewerWidget.py
@@ -56,6 +56,8 @@ class QCILViewerWidget(QtWidgets.QFrame):
                                  iren=self.iren,
                                  debug=debug,
                                  enableSliderWidget=enableSliderWidget)
+            al = self.viewer.axisLabelsText
+            self.viewer.setAxisLabels([al[0], al[1], ''], False)
         elif viewer is viewer3D:
             self.viewer = viewer(dimx=dimx,
                                  dimy=dimy,


### PR DESCRIPTION
## Describe your changes
- edit the axes when the 2d viewer is firstly created

## Describe any testing you have performed
*Consider adding example code to [examples](https://github.com/vais-ral/CILViewer/tree/pr-template/Wrappers/Python/examples)*
- ran standolone app and loaded data

## Link relevant issues
#405 

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the [CIL developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html)
- [ ] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'waiting for review' 

## Contribution Notes
- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CILViewer (the Work) under the terms and conditions of the [Apache-2.0 License](https://spdx.org/licenses/Apache-2.0.html)
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties

Qt contributions should follow Qt naming conventions i.e. camelCase method names.

VTK contributions should follow VTK naming conventions i.e. PascalCase method names.
