### PR TITLE
link slider events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 New functionality:
 - Add method to edit axes label text & tests, hide one label on 2D viewer #389 #408
-- Add slider widget #365 and option to not install it #386. Link slider events (#413)
+- Add slider widget #365 and option to not install it #386. Link slider events #413
 
 Bugfixes:
 - Fix failing unit test #394

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 New functionality:
 - Add method to edit axes label text & tests, hide one label on 2D viewer #389 #408
-- Add slider widget #365 and option to not install it #386
+- Add slider widget #365 and option to not install it #386. Link slider events (#413)
 
 Bugfixes:
 - Fix failing unit test #394

--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -1497,7 +1497,7 @@ class CILViewer2D(CILViewerBase):
         cb = SliderCallback(self, sw)
 
         # Add interaction observers
-        # propagate events from the slider to the viewer
+        # to propagate events from the slider to the viewer
         sw.AddObserver(vtk.vtkCommand.InteractionEvent, cb)
 
         # propagate events from the viewer to the slider

--- a/Wrappers/Python/ccpi/viewer/viewerLinker.py
+++ b/Wrappers/Python/ccpi/viewer/viewerLinker.py
@@ -315,8 +315,9 @@ class ViewerLinkObserver():
 
         # Slice from the slider
         if event == "NoEvent" and self.linkSlice:
-            # print (f"Event: {event} SLIDER_EVENT: {SLIDER_EVENT}")
-            # guessing that it is a slider event
+            # Although I invoked a SLIDER_EVENT in widgets/slider.py, I noticed that a 
+            # NoEvent is actually emitted/received. Therefore, we will link the slice in case of a 
+            # NoEvent and self.linkSlice=True
             if (not self.linkSlice):
                 shouldPassEvent = False
             else:

--- a/Wrappers/Python/ccpi/viewer/viewerLinker.py
+++ b/Wrappers/Python/ccpi/viewer/viewerLinker.py
@@ -3,6 +3,7 @@
 from ccpi.viewer.CILViewer import CILInteractorStyle as CIL3DInteractorStyle
 from ccpi.viewer.CILViewer2D import CILInteractorStyle as CIL2DInteractorStyle
 
+from ccpi.viewer.widgets.slider import SLIDER_EVENT
 
 class Linked3DInteractorStyle(CIL3DInteractorStyle):
     """
@@ -310,6 +311,19 @@ class ViewerLinkObserver():
                 # Linked, check if orientation is the same
                 if (self.sourceVtkViewer.getSliceOrientation() != self.targetVtkViewer.getSliceOrientation()):
                     shouldPassEvent = False
+
+        # Slice from the slider
+        if event == "NoEvent" and self.linkSlice:
+            # print (f"Event: {event} SLIDER_EVENT: {SLIDER_EVENT}")
+            # guessing that it is a slider event
+            if (not self.linkSlice):
+                shouldPassEvent = False
+            else:
+                # Set current slice
+                sliceno = self.sourceViewer.getActiveSlice()
+                print (f"SliderEvent : {sliceno}")
+                self.targetInteractor.GetInteractorStyle().SetActiveSlice(sliceno)
+                self.targetInteractor.GetInteractorStyle().UpdatePipeline(True)
 
         # KeyPress and orientation
         if (event == "KeyPressEvent" or state == 1026):

--- a/Wrappers/Python/ccpi/viewer/viewerLinker.py
+++ b/Wrappers/Python/ccpi/viewer/viewerLinker.py
@@ -315,8 +315,8 @@ class ViewerLinkObserver():
 
         # Slice from the slider
         if event == "NoEvent" and self.linkSlice:
-            # Although I invoked a SLIDER_EVENT in widgets/slider.py, I noticed that a 
-            # NoEvent is actually emitted/received. Therefore, we will link the slice in case of a 
+            # Although I invoked a SLIDER_EVENT in widgets/slider.py, I noticed that a
+            # NoEvent is actually emitted/received. Therefore, we will link the slice in case of a
             # NoEvent and self.linkSlice=True
             if (not self.linkSlice):
                 shouldPassEvent = False

--- a/Wrappers/Python/ccpi/viewer/viewerLinker.py
+++ b/Wrappers/Python/ccpi/viewer/viewerLinker.py
@@ -323,7 +323,6 @@ class ViewerLinkObserver():
             else:
                 # Set current slice
                 sliceno = self.sourceViewer.getActiveSlice()
-                print(f"SliderEvent : {sliceno}")
                 self.targetInteractor.GetInteractorStyle().SetActiveSlice(sliceno)
                 self.targetInteractor.GetInteractorStyle().UpdatePipeline(True)
 

--- a/Wrappers/Python/ccpi/viewer/widgets/slider.py
+++ b/Wrappers/Python/ccpi/viewer/widgets/slider.py
@@ -2,7 +2,8 @@ import vtk
 import logging
 
 logger = logging.getLogger(__name__)
-
+# Define a new event type
+SLIDER_EVENT = vtk.vtkCommand.UserEvent + 1
 
 class SliceSliderRepresentation(vtk.vtkSliderRepresentation2D):
     """A slider representation for the slice selector slider on a 2D CILViewer
@@ -95,6 +96,7 @@ class SliderCallback:
         value = slider_widget.GetRepresentation().GetValue()
         self.viewer.displaySlice(int(value))
         self.update_label(value)
+        self.viewer.getInteractor().InvokeEvent(SLIDER_EVENT)
 
     def update_label(self, value):
         '''Update the text label on the slider. This is called by update_from_viewer

--- a/Wrappers/Python/test/test_ui_dialogs.py
+++ b/Wrappers/Python/test/test_ui_dialogs.py
@@ -180,7 +180,9 @@ class TestRawInputDialog(unittest.TestCase):
     def test_getRawAttrs(self):
         rdi = RawInputDialog(self.parent, self.fname)
         got_raw_attrs = rdi.getRawAttrs()
-        expected_raw_attrs = {'shape': [0, 0, 0], 'typecode': 'uint8', 'is_big_endian': False, 'is_fortran': True}
+        expected_raw_attrs = {'shape': [0, 0, 0], 'typecode': 'uint8', 
+                              'is_big_endian': False, 'is_fortran': True,
+                               'preview_slice': 0}
         assert got_raw_attrs == expected_raw_attrs
         rdi.getWidget('dim_X', 'field').setText('1')
         rdi.getWidget('dim_Y', 'field').setText('2')

--- a/Wrappers/Python/test/test_ui_dialogs.py
+++ b/Wrappers/Python/test/test_ui_dialogs.py
@@ -181,8 +181,7 @@ class TestRawInputDialog(unittest.TestCase):
         rdi = RawInputDialog(self.parent, self.fname)
         got_raw_attrs = rdi.getRawAttrs()
         expected_raw_attrs = {'shape': [0, 0, 0], 'typecode': 'uint8', 
-                              'is_big_endian': False, 'is_fortran': True,
-                               'preview_slice': 0}
+                              'is_big_endian': False, 'is_fortran': True}
         assert got_raw_attrs == expected_raw_attrs
         rdi.getWidget('dim_X', 'field').setText('1')
         rdi.getWidget('dim_Y', 'field').setText('2')


### PR DESCRIPTION
## Describe your changes

Adds logic to viewer linker to keep in sync slices on 2 viewers

## Describe any testing you have performed
*Consider adding example code to [examples](https://github.com/vais-ral/CILViewer/tree/pr-template/Wrappers/Python/examples)*


## Link relevant issues

- closes #387 
- closes #396 

## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the [CIL developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html)
- [x] I have implemented unit tests that cover any new or modified functionality
- [x] CHANGELOG.md has been updated with any functionality change
- [x] Request review from all relevant developers
- [x] Change pull request label to 'waiting for review' 

## Contribution Notes
- [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CILViewer (the Work) under the terms and conditions of the [Apache-2.0 License](https://spdx.org/licenses/Apache-2.0.html)
- [x] I confirm that the contribution does not violate any intellectual property rights of third parties

Qt contributions should follow Qt naming conventions i.e. camelCase method names.

VTK contributions should follow VTK naming conventions i.e. PascalCase method names.
