### PR TITLE
Fix box-extent bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Enhancements:
   
 Bugfix:
   - Edit slider min value #420
+  - Fix box extent error #425
 
 ## v24.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Enhancements:
   - Add title to ViewerCoordsDockWidget #422
+  - Adds methods to CILviewer and CILviewer2D #425
   
 Bugfix:
   - Edit slider min value #420

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Enhancements:
   
 Bugfix:
   - Edit slider min value #420
-  - Fix box extent error #425
+  - Fix extent error when user clicks in the viewer to create a box by clicking outside of the image #425
 
 ## v24.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Enhancements:
 Bugfix:
   - Edit slider min value #420
   - Fix extent error when user clicks in the viewer to create a box by clicking outside of the image #425
+  - Fix extent error when user enlarges the box outside the image #425
+  - Deprecates `GetImageWorldExtent` #425
 
 ## v24.0.1
 

--- a/Wrappers/Python/ccpi/viewer/CILViewer.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer.py
@@ -418,7 +418,7 @@ class CILInteractorStyle(vtk.vtkInteractorStyleTrackballCamera):
 
     def GetDataExtentInWorld(self):
         """
-        Compute and return the extent of the input data in the rendered world.
+        Compute and return the extent of the input data in world coordinates.
         """
         data_extent_image = self.GetInputData().GetExtent()
         data_extent_world = self.image2worldExtent(data_extent_image)

--- a/Wrappers/Python/ccpi/viewer/CILViewer.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer.py
@@ -421,7 +421,7 @@ class CILInteractorStyle(vtk.vtkInteractorStyleTrackballCamera):
         Compute and return the extent of the input data in world coordinates.
         """
         data_extent_image = self.GetInputData().GetExtent()
-        data_extent_world = self.image2worldExtent(data_extent_image)
+        data_extent_world = self.Image2WorldExtent(data_extent_image)
         return data_extent_world
 
     def GetMinMaxVoxelsFromExtent(self, extent):

--- a/Wrappers/Python/ccpi/viewer/CILViewer.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer.py
@@ -431,14 +431,14 @@ class CILInteractorStyle(vtk.vtkInteractorStyleTrackballCamera):
         voxel_max = extent[1::2]
         return voxel_min, voxel_max
 
-    def image2worldExtent(self, extent):
+    def image2worldExtent(self, extent_image):
         """Given the extent of a box or image, gets the voxels corresponding to the min values in all directions
         and max values in all directions. Then, converts their coordinates in the world coordinate system. 
         Returns the converted extent."""
-        v1_image, v2_image = self.GetMinMaxVoxelsFromExtent(extent)
-        v1_world = self.image2world(v1_image)
-        v2_world = self.image2world(v2_image)
-        extent_world = self.GetExtentFromVoxels(v1_world, v2_world)
+        voxel_min_image, voxel_max_image = self.GetMinMaxVoxelsFromExtent(extent_image)
+        voxel_min_world = self.image2world(voxel_min_image)
+        voxel_max_world = self.image2world(voxel_max_image)
+        extent_world = self.GetExtentFromVoxels(voxel_min_world, voxel_max_world)
         return extent_world
 
     def GetExtentFromVoxels(self, voxel_min, voxel_max):

--- a/Wrappers/Python/ccpi/viewer/CILViewer.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer.py
@@ -413,7 +413,7 @@ class CILInteractorStyle(vtk.vtkInteractorStyleTrackballCamera):
         return [(image_coordinates[i]) * spac[i] + orig[i] for i in range(3)]
 
     def GetImageWorldExtent(self):
-        """Deprecated. Use `GetDataExtentInWorld` and `GetVoxelsFromExtent`."""
+        """Deprecated. Use `GetDataExtentInWorld` and `GetMinMaxVoxelsFromExtent`."""
         return self.image2world(self.GetInputData().GetExtent()[1::2])
 
     def GetDataExtentInWorld(self):
@@ -424,7 +424,7 @@ class CILInteractorStyle(vtk.vtkInteractorStyleTrackballCamera):
         data_extent_world = self.image2worldExtent(data_extent_image)
         return data_extent_world
 
-    def GetVoxelsFromExtent(self, extent):
+    def GetMinMaxVoxelsFromExtent(self, extent):
         """Given the extent of a box or image, gets the voxels corresponding to the min values in all directions
         and max values in all directions."""
         voxel_min = extent[0::2]
@@ -435,7 +435,7 @@ class CILInteractorStyle(vtk.vtkInteractorStyleTrackballCamera):
         """Given the extent of a box or image, gets the voxels corresponding to the min values in all directions
         and max values in all directions. Then, converts their coordinates in the world coordinate system. 
         Returns the converted extent."""
-        v1_image, v2_image = self.GetVoxelsFromExtent(extent)
+        v1_image, v2_image = self.GetMinMaxVoxelsFromExtent(extent)
         v1_world = self.image2world(v1_image)
         v2_world = self.image2world(v2_image)
         extent_world = self.GetExtentFromVoxels(v1_world, v2_world)

--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -224,7 +224,7 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
         Compute and return the extent of the input data in the rendered world.
         """
         data_extent_image = self.GetInputData().GetExtent()
-        data_extent_world = self.image2worldExtent(data_extent_image)
+        data_extent_world = self.Image2WorldExtent(data_extent_image)
         return data_extent_world
 
     def GetMinMaxVoxelsFromExtent(self, extent):
@@ -238,10 +238,10 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
         """Given the extent of a box or image, gets the voxels corresponding to the min values in all directions
         and max values in all directions. Then, converts their coordinates in the world coordinate system. 
         Returns the converted extent."""
-        v1_image, v2_image = self.GetMinMaxVoxelsFromExtent(extent_image)
-        v1_world = self.image2world(v1_image)
-        v2_world = self.image2world(v2_image)
-        extent_world = self.GetExtentFromVoxels(v1_world, v2_world)
+        voxel_min_image, voxel_max_image = self.GetMinMaxVoxelsFromExtent(extent_image)
+        voxel_min_world = self.image2world(voxel_min_image)
+        voxel_max_world = self.image2world(voxel_max_image)
+        extent_world = self.GetExtentFromVoxels(voxel_min_world, voxel_max_world)
         return extent_world
 
     def GetExtentFromVoxels(self, voxel_min, voxel_max):

--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -514,10 +514,29 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
         pd = vtk.vtkPolyData()
         self.GetROIWidget().GetPolyData(pd)
         bounds = pd.GetBounds()
+        
 
         # Set the values of the ll and ur corners
-        ll = (bounds[0], bounds[2], bounds[4])
-        ur = (bounds[1], bounds[3], bounds[5])
+        ll = list((bounds[0], bounds[2], bounds[4]))
+        ur = list((bounds[1], bounds[3], bounds[5]))
+        print(ll,ur)
+        # Get maximum extents of the image in world coords
+        world_image_max = self.GetImageWorldExtent()
+        print(world_image_max)
+        if self.GetSliceOrientation() == SLICE_ORIENTATION_XY:
+            if ll[0] < 0:
+                ll[0] = 0
+            if ll[1] < 0:
+                ll[1] = 0
+            if ur[0] > world_image_max[0]:
+                ur[0] = world_image_max[0]
+            if ur[1] > world_image_max[1]:
+                ur[1] = world_image_max[1]
+            self._viewer.ROIWidget.PlaceWidget([ll[0],ur[0],ll[1], ur[1],0,world_image_max[2]])
+        print(ll,ur)
+
+        #self._viewer.ROIWidget.On()
+        #self.UpdatePipeline()
         vox1 = self.createVox(ll)
         vox2 = self.createVox(ur)
 

--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -216,7 +216,7 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
         return actor, vert, horiz
 
     def GetImageWorldExtent(self):
-        """Deprecated. Use `GetDataExtentInWorld` and `GetVoxelsFromExtent`."""
+        """Deprecated. Use `GetDataExtentInWorld` and `GetMinMaxVoxelsFromExtent`."""
         return self.image2world(self.GetInputData().GetExtent()[1::2])
 
     def GetDataExtentInWorld(self):
@@ -227,7 +227,7 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
         data_extent_world = self.image2worldExtent(data_extent_image)
         return data_extent_world
 
-    def GetVoxelsFromExtent(self, extent):
+    def GetMinMaxVoxelsFromExtent(self, extent):
         """Given the extent of a box or image, gets the voxels corresponding to the min values in all directions
         and max values in all directions."""
         voxel_min = extent[0::2]
@@ -238,7 +238,7 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
         """Given the extent of a box or image, gets the voxels corresponding to the min values in all directions
         and max values in all directions. Then, converts their coordinates in the world coordinate system. 
         Returns the converted extent."""
-        v1_image, v2_image = self.GetVoxelsFromExtent(extent)
+        v1_image, v2_image = self.GetMinMaxVoxelsFromExtent(extent)
         v1_world = self.image2world(v1_image)
         v2_world = self.image2world(v2_image)
         extent_world = self.GetExtentFromVoxels(v1_world, v2_world)
@@ -545,13 +545,13 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
         bounds = pd.GetBounds()
 
         # Set the values of the ll and ur corners
-        box_voxel_min, box_voxel_max = self.GetVoxelsFromExtent(bounds)
+        box_voxel_min, box_voxel_max = self.GetMinMaxVoxelsFromExtent(bounds)
         box_voxel_min = list(box_voxel_min)
         box_voxel_max = list(box_voxel_max)
         # Get maximum extents of the image in world coords
         data_extent = self.GetDataExtentInWorld()
 
-        voxel_min_world, voxel_max_world = self.GetVoxelsFromExtent(data_extent)
+        voxel_min_world, voxel_max_world = self.GetMinMaxVoxelsFromExtent(data_extent)
         orientation = self.GetSliceOrientation()
         i = [orientation, (orientation + 1) % 3, (orientation + 2) % 3]
         if box_voxel_min[i[1]] < voxel_min_world[i[1]]:
@@ -1838,7 +1838,7 @@ class CILViewer2D(CILViewerBase):
 
             # Calculate the far right border
             data_extent = self.style.GetDataExtentInWorld()
-            top_right_world = self.style.GetVoxelsFromExtent(data_extent)[1]
+            top_right_world = self.style.GetMinMaxVoxelsFromExtent(data_extent)[1]
             top_right_disp = self.style.world2display(top_right_world)
             top_right_nview = self.style.display2normalisedViewport(
                 (top_right_disp[0] + border + height, top_right_disp[1]))

--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -557,29 +557,28 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
         
 
         # Set the values of the ll and ur corners
-        ll = list((bounds[0], bounds[2], bounds[4]))
-        ur = list((bounds[1], bounds[3], bounds[5]))
-        print(ll,ur)
+        box_voxel_min, box_voxel_max = self.GetVoxelsFromExtent(bounds)
+        box_voxel_min = list(box_voxel_min)
+        box_voxel_max = list(box_voxel_max)
         # Get maximum extents of the image in world coords
         data_extent = self.GetDataWorldExtent()
-        world_image_max = self.GetVoxelsFromExtent(data_extent)[1]
-        print(world_image_max)
-        if self.GetSliceOrientation() == SLICE_ORIENTATION_XY:
-            if ll[0] < 0:
-                ll[0] = 0
-            if ll[1] < 0:
-                ll[1] = 0
-            if ur[0] > world_image_max[0]:
-                ur[0] = world_image_max[0]
-            if ur[1] > world_image_max[1]:
-                ur[1] = world_image_max[1]
-            self._viewer.ROIWidget.PlaceWidget([ll[0],ur[0],ll[1], ur[1],0,world_image_max[2]])
-        print(ll,ur)
-
+        voxel_min_world, voxel_max_world = self.GetVoxelsFromExtent(data_extent)
+        orientation = self.GetSliceOrientation()
+        i = [orientation, (orientation+1)%3, (orientation+2)%3]
+        if box_voxel_min[i[1]] < voxel_min_world[i[1]]:
+            box_voxel_min[i[1]] = voxel_min_world[i[1]]
+        if box_voxel_min[i[2]] < voxel_min_world[i[2]]:
+            box_voxel_min[i[2]] = voxel_min_world[i[2]]
+        if box_voxel_max[i[1]] > voxel_max_world[i[1]]:
+            box_voxel_max[i[1]] = voxel_max_world[i[1]]
+        if box_voxel_max[i[2]] > voxel_max_world[i[2]]:
+            box_voxel_max[i[2]] = voxel_max_world[i[2]]
+        box_extent_world = self.GetExtentFromVoxels(box_voxel_min, box_voxel_max)
+        self._viewer.ROIWidget.PlaceWidget(box_extent_world)
         #self._viewer.ROIWidget.On()
         #self.UpdatePipeline()
-        vox1 = self.createVox(ll)
-        vox2 = self.createVox(ur)
+        vox1 = self.createVox(voxel_min_world)
+        vox2 = self.createVox(voxel_max_world)
 
         # Set the ROI using image coordinates
         self.SetROI((vox1, vox2))

--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -550,10 +550,10 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
         box_voxel_max = list(box_voxel_max)
         # Get maximum extents of the image in world coords
         data_extent = self.GetDataExtentInWorld()
-        
+
         voxel_min_world, voxel_max_world = self.GetVoxelsFromExtent(data_extent)
         orientation = self.GetSliceOrientation()
-        i = [orientation, (orientation+1)%3, (orientation+2)%3]
+        i = [orientation, (orientation + 1) % 3, (orientation + 2) % 3]
         if box_voxel_min[i[1]] < voxel_min_world[i[1]]:
             box_voxel_min[i[1]] = voxel_min_world[i[1]]
         if box_voxel_min[i[2]] < voxel_min_world[i[2]]:

--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -228,14 +228,14 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
         print("max", self.GetInputData().GetExtent()[1::2])
         return self.image2world(self.GetInputData().GetExtent()[1::2])
 
-    def GetImageWorldExtent(self):
+    def GetDataWorldExtent(self):
         """
-        Compute and return the maximum extent of the image in the rendered world
+        Compute and return the extent of the input data in the rendered world.
         """
-        extent_im = self.GetInputData().GetExtent()
-        extent_world = self.image2worldFromExtent(extent_im)
-        print("extent_world",extent_world)
-        return extent_world
+        data_extent_image = self.GetInputData().GetExtent()
+        data_extent_world = self.image2worldExtent(data_extent_image)
+        print("extent_world",data_extent_world)
+        return data_extent_world
 
     def GetVoxelsFromExtent(self, extent):
         v1 = extent[0::2]
@@ -247,10 +247,10 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
         v1, v2 = self.GetVoxelsInImage()
         return self.image2worldForTwoVoxels(v1,v2)
 
-    def image2worldForTwoVoxels(self, v1, v2):
+    def image2worldTwoVoxels(self, v1, v2):
         return self.image2world(v1), self.image2world(v2)
 
-    def image2worldFromExtent(self, extent):
+    def image2worldExtent(self, extent):
         v1_image, v2_image = self.GetVoxelsFromExtent(extent)
         v1_world= self.image2world(v1_image)
         v2_world = self.image2world(v2_image)
@@ -557,8 +557,8 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
         ur = list((bounds[1], bounds[3], bounds[5]))
         print(ll,ur)
         # Get maximum extents of the image in world coords
-        extent = self.GetImageWorldExtent()
-        world_image_max = self.GetVoxelsFromExtent(extent)[1]
+        data_extent = self.GetDataWorldExtent()
+        world_image_max = self.GetVoxelsFromExtent(data_extent)[1]
         print(world_image_max)
         if self.GetSliceOrientation() == SLICE_ORIENTATION_XY:
             if ll[0] < 0:
@@ -1844,8 +1844,8 @@ class CILViewer2D(CILViewerBase):
                 (origin_display[0] - x_min_offset, origin_display[1] - y_min_offset))
 
             # Calculate the far right border
-            extent = self.style.GetImageWorldExtent()
-            top_right_world = self.style.GetVoxelsFromExtent(extent)[1]
+            data_extent = self.style.GetDataWorldExtent()
+            top_right_world = self.style.GetVoxelsFromExtent(data_extent)[1]
             top_right_disp = self.style.world2display(top_right_world)
             top_right_nview = self.style.display2normalisedViewport(
                 (top_right_disp[0] + border + height, top_right_disp[1]))

--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -235,7 +235,7 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
         """
 
         box_pos = cilviewerBoxWidget.GetBoxBoundsFromEventPosition(self._viewer, clickPosition)
-
+        print(box_pos)
         # Set widget placement and make visible
         self._viewer.ROIWidget.PlaceWidget(box_pos)
         self._viewer.ROIWidget.On()
@@ -428,6 +428,7 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
         if ctrl and not (alt and shift):
             self.SetEventActive("CREATE_ROI_EVENT")
             position = interactor.GetEventPosition()
+            print("event position is ",position)
             self.InitialiseBox(position)
             self.SetDisplayHistogram(True)
             self.Render()

--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -550,19 +550,20 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
         box_voxel_max = list(box_voxel_max)
         # Get maximum extents of the image in world coords
         data_extent = self.GetDataExtentInWorld()
-        world_image_max = self.GetVoxelsFromExtent(data_extent)[1]
-        print(world_image_max)
-        if self.GetSliceOrientation() == SLICE_ORIENTATION_XY:
-            if ll[0] < 0:
-                ll[0] = 0
-            if ll[1] < 0:
-                ll[1] = 0
-            if ur[0] > world_image_max[0]:
-                ur[0] = world_image_max[0]
-            if ur[1] > world_image_max[1]:
-                ur[1] = world_image_max[1]
-            self._viewer.ROIWidget.PlaceWidget([ll[0], ur[0], ll[1], ur[1], 0, world_image_max[2]])
-        print(ll, ur)
+        
+        voxel_min_world, voxel_max_world = self.GetVoxelsFromExtent(data_extent)
+        orientation = self.GetSliceOrientation()
+        i = [orientation, (orientation+1)%3, (orientation+2)%3]
+        if box_voxel_min[i[1]] < voxel_min_world[i[1]]:
+            box_voxel_min[i[1]] = voxel_min_world[i[1]]
+        if box_voxel_min[i[2]] < voxel_min_world[i[2]]:
+            box_voxel_min[i[2]] = voxel_min_world[i[2]]
+        if box_voxel_max[i[1]] > voxel_max_world[i[1]]:
+            box_voxel_max[i[1]] = voxel_max_world[i[1]]
+        if box_voxel_max[i[2]] > voxel_max_world[i[2]]:
+            box_voxel_max[i[2]] = voxel_max_world[i[2]]
+        box_extent_world = self.GetExtentFromVoxels(box_voxel_min, box_voxel_max)
+        self._viewer.ROIWidget.PlaceWidget(box_extent_world)
 
         #self._viewer.ROIWidget.On()
         #self.UpdatePipeline()

--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -235,7 +235,6 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
         """
 
         box_pos = cilviewerBoxWidget.GetBoxBoundsFromEventPosition(self._viewer, clickPosition)
-        print(box_pos)
         # Set widget placement and make visible
         self._viewer.ROIWidget.PlaceWidget(box_pos)
         self._viewer.ROIWidget.On()
@@ -428,7 +427,6 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
         if ctrl and not (alt and shift):
             self.SetEventActive("CREATE_ROI_EVENT")
             position = interactor.GetEventPosition()
-            print("event position is ",position)
             self.InitialiseBox(position)
             self.SetDisplayHistogram(True)
             self.Render()

--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -234,11 +234,11 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
         voxel_max = extent[1::2]
         return voxel_min, voxel_max
 
-    def image2worldExtent(self, extent):
+    def image2worldExtent(self, extent_image):
         """Given the extent of a box or image, gets the voxels corresponding to the min values in all directions
         and max values in all directions. Then, converts their coordinates in the world coordinate system. 
         Returns the converted extent."""
-        v1_image, v2_image = self.GetMinMaxVoxelsFromExtent(extent)
+        v1_image, v2_image = self.GetMinMaxVoxelsFromExtent(extent_image)
         v1_world = self.image2world(v1_image)
         v2_world = self.image2world(v2_image)
         extent_world = self.GetExtentFromVoxels(v1_world, v2_world)

--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -575,7 +575,7 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
         box_extent_world = pd.GetBounds()
         box_voxel_min_world, box_voxel_max_world = self.GetMinMaxVoxelsFromExtent(box_extent_world)
         box_voxel_min_image = self.createVox(box_voxel_min_world)
-        box_voxel_max_image  = self.createVox(box_voxel_max_world)
+        box_voxel_max_image = self.createVox(box_voxel_max_world)
         box_extent_image = self.GetExtentFromVoxels(box_voxel_min_image, box_voxel_max_image)
         return box_extent_image
 

--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -552,8 +552,8 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
         data_extent = self.GetDataExtentInWorld()
 
         voxel_min_world, voxel_max_world = self.GetMinMaxVoxelsFromExtent(data_extent)
-        orientation = self.GetSliceOrientation()
-        i = [orientation, (orientation + 1) % 3, (orientation + 2) % 3]
+        i = [self.GetSliceOrientation()]
+        i.extend([(i[0] + 1) % 3, (i[0] + 2) % 3])
         if box_voxel_min[i[1]] < voxel_min_world[i[1]]:
             box_voxel_min[i[1]] = voxel_min_world[i[1]]
         if box_voxel_min[i[2]] < voxel_min_world[i[2]]:

--- a/Wrappers/Python/ccpi/viewer/CILViewer2D.py
+++ b/Wrappers/Python/ccpi/viewer/CILViewer2D.py
@@ -254,8 +254,12 @@ class CILInteractorStyle(vtk.vtkInteractorStyle):
         v1_image, v2_image = self.GetVoxelsFromExtent(extent)
         v1_world= self.image2world(v1_image)
         v2_world = self.image2world(v2_image)
-        extent_world = (v1_world[0], v2_world[0], v1_world[1], v2_world[1], v1_world[2], v2_world[2])
+        extent_world = self.GetExtentFromVoxels(v1_world, v2_world)
         return extent_world
+    
+    def GetExtentFromVoxels(self, v1, v2):
+        extent = (v1[0], v2[0], v1[1], v2[1], v1[2], v2[2])
+        return extent
 
     def SetCharEvent(self, char):
         self.GetInteractor().SetKeyCode(char)

--- a/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
+++ b/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
@@ -136,7 +136,6 @@ class cilviewerBoxWidget():
 
         # Get maximum extents of the image in world coords
         data_extent = viewer.style.GetDataExtentInWorld()
-        print(viewer.style.GetVoxelsFromExtent(data_extent))
         voxel_max_world = viewer.style.GetVoxelsFromExtent(data_extent)[1]
 
         # Set the minimum world value

--- a/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
+++ b/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
@@ -135,9 +135,9 @@ class cilviewerBoxWidget():
         spacing = viewer.img3D.GetSpacing()
 
         # Get maximum extents of the image in world coords
-        extent = viewer.style.GetImageWorldExtent()
-        print(viewer.style.GetVoxelsFromExtent(extent))
-        world_image_max = viewer.style.GetVoxelsFromExtent(extent)[1]
+        data_extent = viewer.style.GetDataWorldExtent()
+        print(viewer.style.GetVoxelsFromExtent(data_extent))
+        world_image_max = viewer.style.GetVoxelsFromExtent(data_extent)[1]
 
 
         # Set the minimum world value
@@ -212,10 +212,10 @@ class cilviewerBoxWidget():
         world_mouse_pos = coord.GetComputedWorldValue(viewer.style.GetRenderer())
 
         # Get maximum extents of the image in world coords
-        extent = viewer.style.GetImageWorldExtent()
-        print("box extent",extent)
+        data_extent = viewer.style.GetDataWorldExtent()
+        print("box extent", data_extent)
         
-        world_image_max = viewer.style.GetVoxelsFromExtent(extent)[1]
+        world_image_max = viewer.style.GetVoxelsFromExtent(data_extent)[1]
         print("box max",world_image_max)
         # Set the minimum world value
         world_image_min = (0, 0, 0)

--- a/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
+++ b/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
@@ -135,7 +135,7 @@ class cilviewerBoxWidget():
         spacing = viewer.img3D.GetSpacing()
 
         # Get maximum extents of the image in world coords
-        data_extent = viewer.style.GetDataWorldExtent()
+        data_extent = viewer.style.GetDataExtentInWorld()
         print(viewer.style.GetVoxelsFromExtent(data_extent))
         voxel_max_world = viewer.style.GetVoxelsFromExtent(data_extent)[1]
 
@@ -213,7 +213,7 @@ class cilviewerBoxWidget():
         coord.SetValue(position[0], position[1])
         mouse_pos_world = coord.GetComputedWorldValue(viewer.style.GetRenderer())
 
-        data_extent_world = viewer.style.GetDataWorldExtent()
+        data_extent_world = viewer.style.GetDataExtentInWorld()
         voxel_min_world, voxel_max_world = viewer.style.GetVoxelsFromExtent(data_extent_world)
 
         dialog = WarningDialog(None, message="Click inside the image.", window_title="Viewer Warning")

--- a/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
+++ b/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
@@ -186,7 +186,7 @@ class cilviewerBoxWidget():
     def GetBoxBoundsFromEventPosition(viewer, position, scale_factor=0.3):
         ''' 
         Get the coordinates for the bounds of a box from the event position.
-        Depending on the viewer orientation, opends a warning dialog when the mouse click is outside the image.
+        Depending on the viewer orientation, opens a warning dialog when the mouse click is outside the image.
 
         Parameters
         ----------

--- a/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
+++ b/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
@@ -201,7 +201,7 @@ class cilviewerBoxWidget():
         viewer
             The 2D viewer where a projection of the 3D box will be displayed as a rectangle.
         position
-            The event position in display coordinates, i.e., 2D coordinates of a mouse click on the image with a specific orientation. 
+            The event position in display coordinates, i.e., 3D coordinates of a mouse click on the image. 
         scale_factor
             Factor for scaling the size of the box to be smaller than the image shape.
         '''
@@ -218,6 +218,23 @@ class cilviewerBoxWidget():
         voxel_min_world, voxel_max_world = viewer.style.GetVoxelsFromExtent(data_extent_world)
         
         dialog = WarningDialog(None, message="Click inside the image.", window_title="Viewer Warning")
+
+        v1 = []
+        v2 = []
+        i= [orientation, (orientation+1)%3, (orientation+2)%3]
+        print(i)
+        if voxel_min_world[i[1]] <= mouse_pos_world[i[1]]<= voxel_max_world[i[1]] and voxel_min_world[i[2]] <= mouse_pos_world[i[2]] <= voxel_max_world[i[2]]:
+
+            v1[i[0]] = voxel_min_world[i[0]]
+            v1[i[1]] = mouse_pos_world[i[1]]
+            v1[i[2]] = mouse_pos_world[i[2]]
+
+            v2[i[0]] = voxel_max_world[i[0]]
+            v2[i[1]] = cilviewerBoxWidget.GetTruncatedBoxCoord(v1[i[1]], data_extent_world, i[1])
+            v2[i[2]] = cilviewerBoxWidget.GetTruncatedBoxCoord(v1[i[2]], data_extent_world, i[2])
+
+        else:
+            dialog.exec()
 
         if orientation == SLICE_ORIENTATION_XY:
             # Looking along z
@@ -281,7 +298,7 @@ class cilviewerBoxWidget():
         return box_extent_world
 
     @staticmethod
-    def GetTruncatedBoxCoord(start_pos, world_extent, axis, scale_factor=0.3):
+    def GetTruncatedBoxCoord(start_pos, world_extent, axis_int, scale_factor=0.3):
         """
         Returns a coordinate for the edge of the box on axis [axis], scaled
         by factor [scale_factor], and truncated to make sure the box does not
@@ -293,8 +310,11 @@ class cilviewerBoxWidget():
             Lower left corner value on specified axis
         world_extent:
             Array containing the extent of the world
-        slice_orientation: str, {'x', 'y', 'z'}
+        axis_int: int 0, 1, 2
             The axis to truncate on.
+            SLICE_ORIENTATION_XY = 2  # Z
+            SLICE_ORIENTATION_XZ = 1  # Y
+            SLICE_ORIENTATION_YZ = 0  # X
         scale_factor: float
             The factor used to scale the length of the box, compared to the extent
             of the world on the given axis. 
@@ -305,9 +325,6 @@ class cilviewerBoxWidget():
         """
 
         # get index for axis
-        axis_dict = {"x": SLICE_ORIENTATION_YZ, "y": SLICE_ORIENTATION_XZ, "z": SLICE_ORIENTATION_XY}
-        axis_int = axis_dict[axis]
-
         world_length = world_extent[2 * axis_int + 1] - world_extent[2 * axis_int]
         dist = world_length * scale_factor
         value = start_pos + dist

--- a/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
+++ b/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
@@ -135,7 +135,10 @@ class cilviewerBoxWidget():
         spacing = viewer.img3D.GetSpacing()
 
         # Get maximum extents of the image in world coords
-        world_image_max = viewer.style.GetImageWorldExtent()
+        extent = viewer.style.GetImageWorldExtent()
+        print(viewer.style.GetVoxelsFromExtent(extent))
+        world_image_max = viewer.style.GetVoxelsFromExtent(extent)[1]
+
 
         # Set the minimum world value
         world_image_min = (0, 0, 0)
@@ -209,7 +212,11 @@ class cilviewerBoxWidget():
         world_mouse_pos = coord.GetComputedWorldValue(viewer.style.GetRenderer())
 
         # Get maximum extents of the image in world coords
-        world_image_max = viewer.style.GetImageWorldExtent()
+        extent = viewer.style.GetImageWorldExtent()
+        print("box extent",extent)
+        
+        world_image_max = viewer.style.GetVoxelsFromExtent(extent)[1]
+        print("box max",world_image_max)
         # Set the minimum world value
         world_image_min = (0, 0, 0)
 

--- a/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
+++ b/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
@@ -188,7 +188,7 @@ class cilviewerBoxWidget():
         ''' 
         Given a position of the click, translates it into world coordinates.
         Gets the current render orientation.
-        Gets the extent of the data in world coordiantes and its corresponding voxels. 
+        Gets the extent of the data in world coordinates and its corresponding voxels. 
         Creates a warning dialog.
         Creates a 3D box around the clicked point, where the clicked point is the voxel min (lower value in all axes).
         Returns its extent in world coordinates, i.e., "box bounds". 

--- a/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
+++ b/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
@@ -203,20 +203,16 @@ class cilviewerBoxWidget():
 
         # Translate the mouse click display coordinates into world coordinates
         coord = vtk.vtkCoordinate()
-        print("coord is ",coord)
         coord.SetCoordinateSystemToDisplay()
         coord.SetValue(position[0], position[1])
         world_mouse_pos = coord.GetComputedWorldValue(viewer.style.GetRenderer())
-        print("world_mouse_pos is",world_mouse_pos)
         
         # Get maximum extents of the image in world coords
         world_image_max = viewer.style.GetImageWorldExtent()
-        print("world_image_max is ",world_image_max)
         # Set the minimum world value
         world_image_min = (0, 0, 0)
 
         world_extent = [0, world_image_max[0], 0, world_image_max[1], 0, world_image_max[2]]
-        print("world_extent is",world_extent)
         # Initialise the box position in format [xmin, xmax, ymin, ymax,...]
         
         dialog = WarningDialog(None, message="Click inside the image.", window_title="Viewer Warning")

--- a/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
+++ b/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
@@ -219,81 +219,23 @@ class cilviewerBoxWidget():
         
         dialog = WarningDialog(None, message="Click inside the image.", window_title="Viewer Warning")
 
-        v1 = []
-        v2 = []
-        i= [orientation, (orientation+1)%3, (orientation+2)%3]
-        print(i)
+        box_voxel_min = [0,0,0]
+        box_voxel_max = [0,0,0]
+        i = [orientation, (orientation+1)%3, (orientation+2)%3]
         if voxel_min_world[i[1]] <= mouse_pos_world[i[1]]<= voxel_max_world[i[1]] and voxel_min_world[i[2]] <= mouse_pos_world[i[2]] <= voxel_max_world[i[2]]:
 
-            v1[i[0]] = voxel_min_world[i[0]]
-            v1[i[1]] = mouse_pos_world[i[1]]
-            v1[i[2]] = mouse_pos_world[i[2]]
+            box_voxel_min[i[0]] = voxel_min_world[i[0]]
+            box_voxel_min[i[1]] = mouse_pos_world[i[1]]
+            box_voxel_min[i[2]] = mouse_pos_world[i[2]]
 
-            v2[i[0]] = voxel_max_world[i[0]]
-            v2[i[1]] = cilviewerBoxWidget.GetTruncatedBoxCoord(v1[i[1]], data_extent_world, i[1])
-            v2[i[2]] = cilviewerBoxWidget.GetTruncatedBoxCoord(v1[i[2]], data_extent_world, i[2])
+            box_voxel_max[i[0]] = voxel_max_world[i[0]]
+            box_voxel_max[i[1]] = cilviewerBoxWidget.GetTruncatedBoxCoord(box_voxel_min[i[1]], data_extent_world, i[1])
+            box_voxel_max[i[2]] = cilviewerBoxWidget.GetTruncatedBoxCoord(box_voxel_min[i[2]], data_extent_world, i[2])
+
+            box_extent_world = viewer.style.GetExtentFromVoxels(box_voxel_min, box_voxel_max)
 
         else:
             dialog.exec()
-
-        if orientation == SLICE_ORIENTATION_XY:
-            # Looking along z
-            if voxel_min_world[0] <= mouse_pos_world[0] <= voxel_max_world[0] and voxel_min_world[1] <= mouse_pos_world[1] <= voxel_max_world[1]:
-
-                # Lower left is xmin, ymin
-                box_extent_world[0] = mouse_pos_world[0]
-                box_extent_world[2] = mouse_pos_world[1]
-
-                # Set top right point
-                # Top right is xmax, ymax
-                box_extent_world[1] = cilviewerBoxWidget.GetTruncatedBoxCoord(box_extent_world[0], data_extent_world, "x", scale_factor)
-                box_extent_world[3] = cilviewerBoxWidget.GetTruncatedBoxCoord(box_extent_world[2], data_extent_world, "y", scale_factor)
-
-                # Set the scroll axis to maximum extent eg. min-max
-                # zmin, zmax
-                box_extent_world[4] = voxel_min_world[orientation]
-                box_extent_world[5] = voxel_max_world[orientation]
-            else:
-                dialog.exec()
-
-        elif orientation == SLICE_ORIENTATION_YZ:
-            # orientation == 0
-            # Looking along x
-            if voxel_min_world[1] <= mouse_pos_world[1] <= voxel_max_world[1] and voxel_min_world[2] <= mouse_pos_world[2] <= voxel_max_world[2]:
-                # Lower left is ymin, zmin
-                box_extent_world[2] = mouse_pos_world[1]
-                box_extent_world[4] = mouse_pos_world[2]
-
-                # Set top right point
-                # Top right is ymax, zmax
-                box_extent_world[3] = cilviewerBoxWidget.GetTruncatedBoxCoord(box_extent_world[2], data_extent_world, "y")
-                box_extent_world[5] = cilviewerBoxWidget.GetTruncatedBoxCoord(box_extent_world[4], data_extent_world, "z")
-
-                # Set the scroll axis to maximum extent eg. min-max
-                # xmin, xmax
-                box_extent_world[0] = voxel_min_world[orientation]
-                box_extent_world[1] = voxel_max_world[orientation]
-            else:
-                dialog.exec()
-
-        elif orientation == SLICE_ORIENTATION_XZ:
-            # Looking along y
-            if voxel_min_world[2] <= mouse_pos_world[2] <= voxel_max_world[2] and voxel_min_world[0] <= mouse_pos_world[0] <= voxel_max_world[0]:
-                # Lower left is xmin, zmin
-                box_extent_world[4] = mouse_pos_world[2]
-                box_extent_world[0] = mouse_pos_world[0]
-
-                # Set top right point.
-                # Top right is xmax, zmax
-                box_extent_world[5] = cilviewerBoxWidget.GetTruncatedBoxCoord(box_extent_world[4], data_extent_world, "z")
-                box_extent_world[1] = cilviewerBoxWidget.GetTruncatedBoxCoord(box_extent_world[0], data_extent_world, "x")
-
-                # Set the scroll axis to maximum extent eg. min-max
-                # ymin, ymax
-                box_extent_world[2] = voxel_min_world[orientation]
-                box_extent_world[3] = voxel_max_world[orientation]
-            else:
-                dialog.exec()
 
         return box_extent_world
 

--- a/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
+++ b/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
@@ -280,7 +280,6 @@ class cilviewerBoxWidget():
         else:
             return value
 
-
 class cilviewerLineWidget():
 
     @staticmethod

--- a/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
+++ b/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
@@ -136,7 +136,7 @@ class cilviewerBoxWidget():
 
         # Get maximum extents of the image in world coords
         data_extent = viewer.style.GetDataExtentInWorld()
-        voxel_max_world = viewer.style.GetVoxelsFromExtent(data_extent)[1]
+        voxel_max_world = viewer.style.GetMinMaxVoxelsFromExtent(data_extent)[1]
 
         # Set the minimum world value
         world_image_min = (0, 0, 0)
@@ -213,7 +213,7 @@ class cilviewerBoxWidget():
         mouse_pos_world = coord.GetComputedWorldValue(viewer.style.GetRenderer())
 
         data_extent_world = viewer.style.GetDataExtentInWorld()
-        voxel_min_world, voxel_max_world = viewer.style.GetVoxelsFromExtent(data_extent_world)
+        voxel_min_world, voxel_max_world = viewer.style.GetMinMaxVoxelsFromExtent(data_extent_world)
 
         dialog = WarningDialog(None, message="Click inside the image.", window_title="Viewer Warning")
 

--- a/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
+++ b/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
@@ -158,7 +158,7 @@ class cilviewerBoxWidget():
         return coords
 
     @staticmethod
-    def CreateMoveableAtEventPosition(viewer, position, widget_name, outline_colour=(0, 1, 0), scale_factor=0.3):
+    def CreateMoveableAtEventPosition(viewer, position, widget_name, outline_colour=(0, 1, 0), box_bounds = None, scale_factor = None):
         ''' 
         Place a moveable box widget on the viewer at the event position.
         Parameters
@@ -176,9 +176,13 @@ class cilviewerBoxWidget():
         '''
         # ROI Widget
         widget = cilviewerBoxWidget.CreateMoveable(viewer, outline_colour)
-        coords = cilviewerBoxWidget.GetBoxBoundsFromEventPosition(viewer, position, scale_factor)
+        if box_bounds == None:
+            if scale_factor == None:
+                box_bounds = cilviewerBoxWidget.GetBoxBoundsFromEventPosition(viewer, position)
+            else:
+                box_bounds = cilviewerBoxWidget.GetBoxBoundsFromEventPosition(viewer, position, scale_factor = scale_factor)
         # Set widget placement and make visible
-        widget.PlaceWidget(coords)
+        widget.PlaceWidget(box_bounds)
         widget.On()
         viewer.addWidgetReference(widget, widget_name)
         return widget

--- a/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
+++ b/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
@@ -207,7 +207,7 @@ class cilviewerBoxWidget():
         coord.SetCoordinateSystemToDisplay()
         coord.SetValue(position[0], position[1])
         world_mouse_pos = coord.GetComputedWorldValue(viewer.style.GetRenderer())
-        
+
         # Get maximum extents of the image in world coords
         world_image_max = viewer.style.GetImageWorldExtent()
         # Set the minimum world value

--- a/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
+++ b/Wrappers/Python/ccpi/viewer/widgets/box_widgets.py
@@ -158,7 +158,12 @@ class cilviewerBoxWidget():
         return coords
 
     @staticmethod
-    def CreateMoveableAtEventPosition(viewer, position, widget_name, outline_colour=(0, 1, 0), box_bounds = None, scale_factor = None):
+    def CreateMoveableAtEventPosition(viewer,
+                                      position,
+                                      widget_name,
+                                      outline_colour=(0, 1, 0),
+                                      box_bounds=None,
+                                      scale_factor=None):
         ''' 
         Place a moveable box widget on the viewer at the event position.
         Parameters
@@ -180,7 +185,9 @@ class cilviewerBoxWidget():
             if scale_factor == None:
                 box_bounds = cilviewerBoxWidget.GetBoxBoundsFromEventPosition(viewer, position)
             else:
-                box_bounds = cilviewerBoxWidget.GetBoxBoundsFromEventPosition(viewer, position, scale_factor = scale_factor)
+                box_bounds = cilviewerBoxWidget.GetBoxBoundsFromEventPosition(viewer,
+                                                                              position,
+                                                                              scale_factor=scale_factor)
         # Set widget placement and make visible
         widget.PlaceWidget(box_bounds)
         widget.On()
@@ -279,6 +286,7 @@ class cilviewerBoxWidget():
             return world_extent[2 * axis_int + 1]
         else:
             return value
+
 
 class cilviewerLineWidget():
 


### PR DESCRIPTION
- Closes #424 
- Closes https://github.com/TomographicImaging/CILViewer/issues/426

  - Fix extent error when user clicks in the viewer to create a box by clicking outside of the image 
  - Fix extent error when user enlarges the box outside the image 
  - Deprecates `GetImageWorldExtent` 
  - Adds methods to `CILviewer` and `CILviewer2D`
 
Deprecates 
Notes:
for Edo: In fixing this bug I made the box 3D, where the 3rd dimension == orientation is taken in its full length. Is this what we want? Or do we want a 2D box on the slice selected?

Edo: We want a 3D box.