### PR TITLE
use offscreen rendering in VTK unit tests

### DIFF
--- a/.github/workflows/docker_build_test_publish.yml
+++ b/.github/workflows/docker_build_test_publish.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Run docker container with tests
         shell: bash -l {0}
         run: |
-          docker run --rm --entrypoint /bin/bash -v /home/runner/work/CILViewer/CILViewer:/root/source_code  cil-viewer -c "source ./mambaforge/etc/profile.d/conda.sh && conda activate cilviewer_webapp && conda install cil-data pytest pyside2 eqt>=1.0.0 -c ccpi && python -m pytest /root/source_code/Wrappers/Python -k 'not test_version and not test_cli_resample and not test_CILViewerBase and not test_CILViewer3D and not test_viewer_main_windows and not test_ui_dialogs'"
+          docker run --rm --entrypoint /bin/bash -v /home/runner/work/CILViewer/CILViewer:/root/source_code  cil-viewer -c "source ./mambaforge/etc/profile.d/conda.sh && conda activate cilviewer_webapp && conda install cil-data pytest pyside2 eqt>=1.0.0 -c ccpi && python -m pytest /root/source_code/Wrappers/Python -k 'not test_version and not test_cli_resample and not test_viewer_main_windows and not test_ui_dialogs'"
     # TODO: publish to come later

--- a/Wrappers/Python/test/test_CILViewer3D.py
+++ b/Wrappers/Python/test/test_CILViewer3D.py
@@ -20,11 +20,9 @@ from unittest import mock
 
 from ccpi.viewer.CILViewer import CILViewer
 
-# skip the tests on GitHub actions
-if os.environ.get('CONDA_BUILD', '0') == '1':
-    skip_test = True
-else:
-    skip_test = False
+from vtkmodules.vtkRenderingCore import vtkGraphicsFactory
+
+skip_test = False
 
 print("skip_test is set to ", skip_test)
 
@@ -33,6 +31,7 @@ print("skip_test is set to ", skip_test)
 class CILViewer3DTest(unittest.TestCase):
 
     def setUp(self):
+        vgf = vtkGraphicsFactory(off_screen_only_mode=True, use_mesa_classes=True)
         self.cil_viewer = CILViewer()
 
     def test_getGradientOpacityPercentiles_returns_correct_percentiles_when_image_values_start_at_zero(self):

--- a/Wrappers/Python/test/test_CILViewerBase.py
+++ b/Wrappers/Python/test/test_CILViewerBase.py
@@ -19,12 +19,9 @@ from unittest import mock
 import os
 
 from ccpi.viewer.CILViewer import CILViewerBase
+from vtkmodules.vtkRenderingCore import vtkGraphicsFactory
 
-# skip the tests on GitHub actions
-if os.environ.get('CONDA_BUILD', '0') == '1':
-    skip_test = True
-else:
-    skip_test = False
+skip_test = False
 
 print("skip_test is set to ", skip_test)
 
@@ -34,6 +31,7 @@ class CILViewerBaseTest(unittest.TestCase):
 
     def setUp(self):
         '''Creates an instance of the CIL viewer base class.'''
+        vgf = vtkGraphicsFactory(off_screen_only_mode=True, use_mesa_classes=True)
         self.CILViewerBase_instance = CILViewerBase()
 
     def test_setAxisLabels(self):
@@ -56,6 +54,7 @@ class CILViewerBaseTest(unittest.TestCase):
 class CILViewer3DTest(unittest.TestCase):
 
     def setUp(self):
+        vgf = vtkGraphicsFactory(off_screen_only_mode=True, use_mesa_classes=True)
         self.cil_viewer = CILViewerBase()
 
     def test_getSliceColorPercentiles_returns_correct_percentiles_when_slice_values_start_at_zero(self):


### PR DESCRIPTION
## Describe your changes

VTK tests used to open a window, therefore were disabled in CI.
Here we set up offscreen rendering, which means that no window is open and unit tests can run in CI.

## Describe any testing you have performed
*Consider adding example code to [examples](https://github.com/vais-ral/CILViewer/tree/pr-template/Wrappers/Python/examples)*


## Link relevant issues


## Checklist when you are ready to request a review

- [ ] I have performed a self-review of my code
- [ ] I have added docstrings in line with the guidance in the [CIL developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html)
- [ ] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'waiting for review' 

## Contribution Notes
- [ ] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CILViewer (the Work) under the terms and conditions of the [Apache-2.0 License](https://spdx.org/licenses/Apache-2.0.html)
- [ ] I confirm that the contribution does not violate any intellectual property rights of third parties

Qt contributions should follow Qt naming conventions i.e. camelCase method names.

VTK contributions should follow VTK naming conventions i.e. PascalCase method names.
